### PR TITLE
Fix for podcast-dl in systemd service

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -205,10 +205,13 @@ let printProgress = ({ percent, total, transferred }) => {
       line += ` of ${roundedTotalMbs} MB`;
     }
   }
-
-  process.stdout.clearLine();
-  process.stdout.cursorTo(0);
-  process.stdout.write(line);
+  try {
+      process.stdout.clearLine();
+      process.stdout.cursorTo(0);
+      process.stdout.write(line);
+  } catch (e) {
+      console.debug(e);
+  }
 };
 
 let endPrintProgress = () => {


### PR DESCRIPTION

I wanted to use a systemd timer to download every week my favourite podcast. 

Unfortunately, when using podcast-dl in a systemd service these two lines throw an error:
https://github.com/lightpohl/podcast-dl/blob/62639808666a1813618263f5a1fcb599aa81324d/bin/util.js#L209
https://github.com/lightpohl/podcast-dl/blob/62639808666a1813618263f5a1fcb599aa81324d/bin/util.js#L210

So there is no need to print the download progress anyways.