### PR TITLE
refactor: VALID_AUDIO_EXTS generation by using Object.values

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -165,13 +165,7 @@ let AUDIO_TYPES_TO_EXTS = {
   "audio/aac": ".aac",
 };
 
-let VALID_AUDIO_EXTS = [
-  ...new Set(
-    Object.keys(AUDIO_TYPES_TO_EXTS).map((key) => {
-      return AUDIO_TYPES_TO_EXTS[key];
-    })
-  ),
-];
+let VALID_AUDIO_EXTS = [...new Set(Object.values(AUDIO_TYPES_TO_EXTS))];
 
 let getIsAudioUrl = (url) => {
   let ext = getUrlExt(url);


### PR DESCRIPTION
I reviewed the changes you implemented for my feature request issue #19 and noticed you did not use Object.values to extract all available file endings from the mapping object that you newly introduced. I hope you don't mind me proposing a small refactoring.
