### PR TITLE
feat: add --add-mp3-metadata option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,25 @@
 
 ## Options
 
-| Option                  | Type   | Required | Description                                                                                                                             |
-| ----------------------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| --url                   | String | true     | URL to podcast RSS feed.                                                                                                                |
-| --out-dir               | String | false    | Specify output directory for episodes and metadata. Defaults to "./{{podcast_title}}". See "Templating" for more details.               |
-| --archive               | String | false    | Download or write out items not listed in archive file. Generates archive file at path if not found. See "Templating" for more details. |
-| --episode-template      | String | false    | Template for generating episode related filenames. See "Templating" for details.                                                        |
-| --include-meta          |        | false    | Write out podcast metadata to JSON.                                                                                                     |
-| --include-episode-meta  |        | false    | Write out individual episode metadata to JSON.                                                                                          |
-| --ignore-episode-images |        | false    | Ignore downloading found images from --include-episode-meta.                                                                            |
-| --offset                | Number | false    | Offset starting download position. Default is 0.                                                                                        |
-| --limit                 | Number | false    | Max number of episodes to download. Downloads all by default.                                                                           |
-| --episode-regex         | String | false    | Match episode title against provided regex before starting download.                                                                    |
-| --override              |        | false    | Override local files on collision.                                                                                                      |
-| --reverse               |        | false    | Reverse download direction and start at last RSS item.                                                                                  |
-| --info                  |        | false    | Print retrieved podcast info instead of downloading.                                                                                    |
-| --list                  |        | false    | Print episode list instead of downloading.                                                                                              |
-| --version               |        | false    | Output the version number.                                                                                                              |
-| --help                  |        | false    | Output usage information.                                                                                                               |
+| Option                  | Type   | Required | Description                                                                                                                                                 |
+| ----------------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --url                   | String | true     | URL to podcast RSS feed.                                                                                                                                    |
+| --out-dir               | String | false    | Specify output directory for episodes and metadata. Defaults to "./{{podcast_title}}". See "Templating" for more details.                                   |
+| --archive               | String | false    | Download or write out items not listed in archive file. Generates archive file at path if not found. See "Templating" for more details.                     |
+| --episode-template      | String | false    | Template for generating episode related filenames. See "Templating" for details.                                                                            |
+| --include-meta          |        | false    | Write out podcast metadata to JSON.                                                                                                                         |
+| --include-episode-meta  |        | false    | Write out individual episode metadata to JSON.                                                                                                              |
+| --ignore-episode-images |        | false    | Ignore downloading found images from --include-episode-meta.                                                                                                |
+| --offset                | Number | false    | Offset starting download position. Default is 0.                                                                                                            |
+| --limit                 | Number | false    | Max number of episodes to download. Downloads all by default.                                                                                               |
+| --episode-regex         | String | false    | Match episode title against provided regex before starting download.                                                                                        |
+| --add-mp3-metadata      |        | false    | Attempts to add a base level of MP3 metadata to each episode. Recommended only in cases where the original metadata is of poor quality. **ffmpeg required** |
+| --override              |        | false    | Override local files on collision.                                                                                                                          |
+| --reverse               |        | false    | Reverse download direction and start at last RSS item.                                                                                                      |
+| --info                  |        | false    | Print retrieved podcast info instead of downloading.                                                                                                        |
+| --list                  |        | false    | Print episode list instead of downloading.                                                                                                                  |
+| --version               |        | false    | Output the version number.                                                                                                                                  |
+| --help                  |        | false    | Output usage information.                                                                                                                                   |
 
 ## Archive
 

--- a/README.md
+++ b/README.md
@@ -24,25 +24,25 @@
 
 ## Options
 
-| Option                  | Type   | Required | Description                                                                                                                                                 |
-| ----------------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| --url                   | String | true     | URL to podcast RSS feed.                                                                                                                                    |
-| --out-dir               | String | false    | Specify output directory for episodes and metadata. Defaults to "./{{podcast_title}}". See "Templating" for more details.                                   |
-| --archive               | String | false    | Download or write out items not listed in archive file. Generates archive file at path if not found. See "Templating" for more details.                     |
-| --episode-template      | String | false    | Template for generating episode related filenames. See "Templating" for details.                                                                            |
-| --include-meta          |        | false    | Write out podcast metadata to JSON.                                                                                                                         |
-| --include-episode-meta  |        | false    | Write out individual episode metadata to JSON.                                                                                                              |
-| --ignore-episode-images |        | false    | Ignore downloading found images from --include-episode-meta.                                                                                                |
-| --offset                | Number | false    | Offset starting download position. Default is 0.                                                                                                            |
-| --limit                 | Number | false    | Max number of episodes to download. Downloads all by default.                                                                                               |
-| --episode-regex         | String | false    | Match episode title against provided regex before starting download.                                                                                        |
-| --add-mp3-metadata      |        | false    | Attempts to add a base level of MP3 metadata to each episode. Recommended only in cases where the original metadata is of poor quality. **ffmpeg required** |
-| --override              |        | false    | Override local files on collision.                                                                                                                          |
-| --reverse               |        | false    | Reverse download direction and start at last RSS item.                                                                                                      |
-| --info                  |        | false    | Print retrieved podcast info instead of downloading.                                                                                                        |
-| --list                  |        | false    | Print episode list instead of downloading.                                                                                                                  |
-| --version               |        | false    | Output the version number.                                                                                                                                  |
-| --help                  |        | false    | Output usage information.                                                                                                                                   |
+| Option                  | Type   | Required | Description                                                                                                                                                   |
+| ----------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| --url                   | String | true     | URL to podcast RSS feed.                                                                                                                                      |
+| --out-dir               | String | false    | Specify output directory for episodes and metadata. Defaults to "./{{podcast_title}}". See "Templating" for more details.                                     |
+| --archive               | String | false    | Download or write out items not listed in archive file. Generates archive file at path if not found. See "Templating" for more details.                       |
+| --episode-template      | String | false    | Template for generating episode related filenames. See "Templating" for details.                                                                              |
+| --include-meta          |        | false    | Write out podcast metadata to JSON.                                                                                                                           |
+| --include-episode-meta  |        | false    | Write out individual episode metadata to JSON.                                                                                                                |
+| --ignore-episode-images |        | false    | Ignore downloading found images from --include-episode-meta.                                                                                                  |
+| --offset                | Number | false    | Offset starting download position. Default is 0.                                                                                                              |
+| --limit                 | Number | false    | Max number of episodes to download. Downloads all by default.                                                                                                 |
+| --episode-regex         | String | false    | Match episode title against provided regex before starting download.                                                                                          |
+| --add-mp3-metadata      |        | false    | Attempts to add a base level of MP3 metadata to each episode. Recommended only in cases where the original metadata is of poor quality. (**ffmpeg required**) |
+| --override              |        | false    | Override local files on collision.                                                                                                                            |
+| --reverse               |        | false    | Reverse download direction and start at last RSS item.                                                                                                        |
+| --info                  |        | false    | Print retrieved podcast info instead of downloading.                                                                                                          |
+| --list                  |        | false    | Print episode list instead of downloading.                                                                                                                    |
+| --version               |        | false    | Output the version number.                                                                                                                                    |
+| --help                  |        | false    | Output usage information.                                                                                                                                     |
 
 ## Archive
 

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -19,6 +19,7 @@ let {
   logItemsList,
   writeFeedMeta,
   writeItemMeta,
+  addMp3Metadata,
 } = require("./util");
 let {
   createParseNumber,
@@ -71,6 +72,10 @@ commander
     "--episode-regex <string>",
     "match episode title against regex before downloading"
   )
+  .option(
+    "--add-mp3-metadata",
+    "attempts to add a base level of metadata to .mp3 files using ffmpeg"
+  )
   .option("--override", "override local files on collision")
   .option("--reverse", "download episodes in reverse order")
   .option("--info", "print retrieved podcast info instead of downloading")
@@ -92,6 +97,7 @@ let {
   reverse,
   info,
   list,
+  addMp3Metadata: addMp3MetadataFlag,
 } = commander;
 
 let main = async () => {
@@ -254,6 +260,19 @@ let main = async () => {
       });
     } catch (error) {
       logError("Unable to download episode", error);
+    }
+
+    if (addMp3MetadataFlag) {
+      try {
+        addMp3Metadata({
+          feed,
+          item,
+          itemIndex: i,
+          outputPath: outputPodcastPath,
+        });
+      } catch (error) {
+        logError("Unable to add episode metadata", error);
+      }
     }
 
     if (includeEpisodeMeta) {


### PR DESCRIPTION
- Adds an experimental flag to use podcast episode info for some of the `.mp3` metadata
- Uses the locally installed version of `ffmpeg` to make the adjustments
- Recommended to only use with if existing metadata embedded in the downloaded `.mp3` is unreliable
- Useful for backing up premium subscription feeds to Plex