### PR TITLE
Exit1on download error

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 | --reverse               |        | false    | Reverse download direction and start at last RSS item.                                                                                                        |
 | --info                  |        | false    | Print retrieved podcast info instead of downloading.                                                                                                          |
 | --list                  |        | false    | Print episode list instead of downloading.                                                                                                                    |
+| --exit-with-error       |        | false    | When episode could not be downloaded exit with error code 1                                                                                                   |
 | --version               |        | false    | Output the version number.                                                                                                                                    |
 | --help                  |        | false    | Output usage information.                                                                                                                                     |
 

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -81,6 +81,10 @@ commander
   .option("--reverse", "download episodes in reverse order")
   .option("--info", "print retrieved podcast info instead of downloading")
   .option("--list", "print episode info instead of downloading")
+  .option(
+    "--exit-with-error",
+    "When episode could not be downloaded exit with error code 1"
+  )
   .parse(process.argv);
 
 const {
@@ -97,6 +101,7 @@ const {
   reverse,
   info,
   list,
+  exitWithError,
   addMp3Metadata: addMp3MetadataFlag,
 } = commander;
 
@@ -228,10 +233,8 @@ const main = async () => {
       continue;
     }
 
-    const {
-      url: episodeAudioUrl,
-      ext: audioFileExt,
-    } = getEpisodeAudioUrlAndExt(item);
+    const { url: episodeAudioUrl, ext: audioFileExt } =
+      getEpisodeAudioUrlAndExt(item);
 
     if (!episodeAudioUrl) {
       logItemInfo(item, LOG_LEVELS.critical);
@@ -271,7 +274,11 @@ const main = async () => {
         },
       });
     } catch (error) {
-      logError("Unable to download episode", error);
+      if (exitWithError) {
+        logErrorAndExit("Unable to download episode", error);
+      } else {
+        logError("Unable to download episode", error);
+      }
     }
 
     if (addMp3MetadataFlag) {


### PR DESCRIPTION
As I mentioned in https://github.com/lightpohl/podcast-dl/pull/17 I use a systemd timer to start `podcast-dl`.

But I realized that my favorite podcast is uploaded often on Thursday mornings, but quite some times on Thursday evenings or even on Friday or Saturday. Either I set my timer on Sunday than I can be sure that the podcast is uploaded already. Or I just retry to download it every three hours until it succeeds by using following:
```
Restart=on-failure
RestartSec=10800
```
However systemd's `Restart=on-failure` just works with exit codes other than zero. So this pull request is one way to achieve this :)