### PR TITLE
Exit with error code 1 when no episode was downloaded

### DIFF
--- a/bin/bin.js
+++ b/bin/bin.js
@@ -355,11 +355,9 @@ const main = async () => {
 
     nextItem();
   }
-  const dlEpisodeText =
-    episodesDownloadedCounter === 1 ? "episode" : "episodes";
-  episodesDownloadedCounter == 0
-    ? logErrorAndExit("No episode downloaded")
-    : logMessage(`${episodesDownloadedCounter} ${dlEpisodeText} downloaded.`);
+  if (episodesDownloadedCounter === 0) {
+    process.exit(2);
+  }
 };
 
 main();

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -208,6 +208,7 @@ const main = async () => {
     counter += 1;
     logMessage("");
   };
+  let dlCounter = 0;
 
   while (limitCheck(i)) {
     const item = feed.items[i];
@@ -268,6 +269,7 @@ const main = async () => {
         },
         onAfterDownload: () => {
           logMessage("", LOG_LEVELS.important);
+          dlCounter += 1;
         },
       });
     } catch (error) {
@@ -355,6 +357,10 @@ const main = async () => {
 
     nextItem();
   }
+  const dlEpisodeText = dlCounter === 1 ? "episode" : "episodes";
+  dlCounter == 0
+    ? logErrorAndExit("No episode downloaded")
+    : logMessage(`${dlCounter} ${dlEpisodeText} downloaded.`);
 };
 
 main();

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -208,7 +208,7 @@ const main = async () => {
     counter += 1;
     logMessage("");
   };
-  let dlCounter = 0;
+  let episodesDownloadedCounter = 0;
 
   while (limitCheck(i)) {
     const item = feed.items[i];
@@ -229,10 +229,8 @@ const main = async () => {
       continue;
     }
 
-    const {
-      url: episodeAudioUrl,
-      ext: audioFileExt,
-    } = getEpisodeAudioUrlAndExt(item);
+    const { url: episodeAudioUrl, ext: audioFileExt } =
+      getEpisodeAudioUrlAndExt(item);
 
     if (!episodeAudioUrl) {
       logItemInfo(item, LOG_LEVELS.critical);
@@ -269,7 +267,7 @@ const main = async () => {
         },
         onAfterDownload: () => {
           logMessage("", LOG_LEVELS.important);
-          dlCounter += 1;
+          episodesDownloadedCounter += 1;
         },
       });
     } catch (error) {
@@ -357,10 +355,11 @@ const main = async () => {
 
     nextItem();
   }
-  const dlEpisodeText = dlCounter === 1 ? "episode" : "episodes";
-  dlCounter == 0
+  const dlEpisodeText =
+    episodesDownloadedCounter === 1 ? "episode" : "episodes";
+  episodesDownloadedCounter == 0
     ? logErrorAndExit("No episode downloaded")
-    : logMessage(`${dlCounter} ${dlEpisodeText} downloaded.`);
+    : logMessage(`${episodesDownloadedCounter} ${dlEpisodeText} downloaded.`);
 };
 
 main();


### PR DESCRIPTION
Just closed #26 and this is a better implementation...

As I mentioned in https://github.com/lightpohl/podcast-dl/pull/17 I use a systemd timer to start `podcast-dl`.

But I realized that my favorite podcast is uploaded often on Thursday mornings, but quite some times on Thursday evenings or even on Friday or Saturday. Either I set my timer on Sunday than I can be sure that the podcast is uploaded already. Or I just retry to download it every three hours until it succeeds by using following:
```
Restart=on-failure
RestartSec=10800
```
However systemd's `Restart=on-failure` just works with exit codes other than zero. So this pull request is one way to achieve this :)