### PR TITLE
More metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Type values surrounded in square brackets (`[]`) can be used as used as boolean 
 | --threads                | Number              | false    | Determines the number of downloads that will happen concurrently. Default is 1.                                                                                                                                       |
 | --archive                | [String]            | false    | Download or write out items not listed in archive file. Generates archive file at path if not found. Defaults to "./{{podcast_title}}/archive.json" when used as a boolean option. See "Templating" for more details. |
 | --episode-template       | String              | false    | Template for generating episode related filenames. See "Templating" for details.                                                                                                                                      |
-| --include-meta           |                     | false    | Write out podcast metadata to JSON.                                                                                                                                                                                   |
-| --include-episode-meta   |                     | false    | Write out individual episode metadata to JSON.                                                                                                                                                                        |
+| --include-meta           | [String]            | false    | Write out podcast metadata. Can be repeated to choose what to fields to include (see [metadata](#metadata)). Defaults to ["title", "description", "link", "feedUrl", "managingEditor"] when used as a boolean option. |
+| --include-episode-meta   | [String]            | false    | Write out individual episode metadata. Can be repeated to choose what to fields to include (see [metadata](#metadata)). Defaults to ["title", "contentSnippet", "pubDate", "creator"] when used as a boolean option.  |
+| --metadata-format        | String              | false    | The format to write the feed and episode metadata in. Either "json" or "xml". Defaults to "json".                                                                                                                     |
 | --include-episode-images |                     | false    | Download found episode images.                                                                                                                                                                                        |
 | --offset                 | Number              | false    | Offset starting download position. Default is 0.                                                                                                                                                                      |
 | --limit                  | Number              | false    | Max number of episodes to download. Downloads all by default.                                                                                                                                                         |
@@ -69,6 +70,146 @@ Options that support templating allow users to specify a template for the genera
 - `duration`: Provided `mm:ss` duration (if found).
 - `podcast_title`: Title of the podcast feed.
 - `podcast_link`: `link` value provided for the podcast feed. Typically the homepage URL.
+
+## Metadata
+
+The metadata options allow you to specify globs to select what to include/exclude. Lets take a look at some metadata to use as an example for how this works.
+
+Lets take the following snippet from the feed's channel info.
+
+<details>
+<summary>XML</summary>
+
+```xml
+<xml>
+    <title>8-4 Play</title>
+    <description><![CDATA[Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.]]></description>
+    <image>
+       <url>https://ssl-static.libsyn.com/p/assets/e/c/1/e/ec1e4c9c798b4df7/84playicon600x600libsyn.jpg</url>
+       <title>8-4 Play</title>
+       <link><![CDATA[http://www.8-4.jp/]]></link>
+    </image>
+    <itunes:summary><![CDATA[Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.]]></itunes:summary>
+    <itunes:subtitle><![CDATA[]]></itunes:subtitle>
+    <itunes:author>8-4, Ltd.</itunes:author>
+    <itunes:owner>
+        <itunes:name><![CDATA[8-4, Ltd.]]></itunes:name>
+        <itunes:email>info@8-4.jp</itunes:email>
+    </itunes:owner>
+    <itunes:keywords>84,360,Games,Microsoft</itunes:keywords>
+</xml>
+```
+
+</details>
+
+This results in the following JSON if everything is included.
+
+<details>
+<summary>Unfiltered JSON</summary>
+
+```json
+{
+  "title": "8-4 Play",
+  "description": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.",
+  "image": {
+    "link": "http://www.8-4.jp/",
+    "url": "https://ssl-static.libsyn.com/p/assets/e/c/1/e/ec1e4c9c798b4df7/84playicon600x600libsyn.jpg",
+    "title": "8-4 Play"
+  },
+  "itunes": {
+    "summary": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.",
+    "subtitle": "",
+    "owner": {
+      "name": "8-4, Ltd.",
+      "email": "info@8-4.jp"
+    },
+    "keywords": ["84", "360", "Games", "Microsoft"]
+  }
+}
+```
+
+</details>
+
+Instead of including everything, you can limit what to include/exclude with the `--include-meta` option. This can be passed multiple times, providing a rule each time. A single asterix matches any field name, but not nested names. A double asterix matches and field nane and any nested name.
+
+<details>
+<summary><code>--include-meta '*'</code></summary>
+
+```json
+{
+  "title": "8-4 Play",
+  "description": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo."
+}
+```
+
+</details>
+
+<details>
+<summary><code>--include-meta '**'</code></summary>
+
+```json
+{
+  "title": "8-4 Play",
+  "description": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.",
+  "image": {
+    "link": "http://www.8-4.jp/",
+    "url": "https://ssl-static.libsyn.com/p/assets/e/c/1/e/ec1e4c9c798b4df7/84playicon600x600libsyn.jpg",
+    "title": "8-4 Play"
+  },
+  "itunes": {
+    "summary": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.",
+    "subtitle": "",
+    "owner": {
+      "name": "8-4, Ltd.",
+      "email": "info@8-4.jp"
+    },
+    "keywords": ["84", "360", "Games", "Microsoft"]
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><code>--include-meta '*' --include-meta 'image.*'</code></summary>
+
+```json
+{
+  "title": "8-4 Play",
+  "description": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.",
+  "image": {
+    "link": "http://www.8-4.jp/",
+    "url": "https://ssl-static.libsyn.com/p/assets/e/c/1/e/ec1e4c9c798b4df7/84playicon600x600libsyn.jpg",
+    "title": "8-4 Play"
+  }
+}
+```
+
+</details>
+
+If a rule starts with an exclamation mark it excludes matching field instead of including them. The last rule to match a field determines whether to include or exclude it, and if no rules match it will be excluded.
+
+<details>
+<summary><code>--include-meta '**' --include-meta '!itunes.*' --include-meta 'itunes.summary'</code></summary>
+
+```json
+{
+  "title": "8-4 Play",
+  "description": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo.",
+  "image": {
+    "link": "http://www.8-4.jp/",
+    "url": "https://ssl-static.libsyn.com/p/assets/e/c/1/e/ec1e4c9c798b4df7/84playicon600x600libsyn.jpg",
+    "title": "8-4 Play"
+  },
+  "itunes": {
+    "summary": "Every other week, tune into 8-4 Play for talk about Japan, video games, and Japanese video games, straight from the 8-4 offices in beautiful downtown Tokyo."
+  }
+}
+```
+
+</details>
+
+To get an overview of what fields are available (which may differ per feed), just use include everything (`--include-meta '**'` or `--include-episode-meta '**'`) and check the resulting file.
 
 ## Executing Process After Downloading Episode
 

--- a/bin/async.js
+++ b/bin/async.js
@@ -159,6 +159,7 @@ let downloadItemsAsync = async ({
   feed,
   filterUrlTracking,
   includeEpisodeMeta,
+  includeEpisodeMetaFields,
   mono,
   override,
   targetItems,
@@ -278,6 +279,7 @@ let downloadItemsAsync = async ({
             }),
           }),
           outputPath: outputEpisodeMetaPath,
+          extraFields: includeEpisodeMetaFields,
         });
       } catch (error) {
         hasErrors = true;

--- a/bin/async.js
+++ b/bin/async.js
@@ -158,8 +158,7 @@ let downloadItemsAsync = async ({
   exec,
   feed,
   filterUrlTracking,
-  includeEpisodeMeta,
-  includeEpisodeMetaFields,
+  fields,
   mono,
   override,
   targetItems,
@@ -252,7 +251,7 @@ let downloadItemsAsync = async ({
       }
     }
 
-    if (includeEpisodeMeta) {
+    if (fields && fields.length) {
       const episodeMetaExt = ".meta.json";
       const episodeMetaName = getFilename({
         item,
@@ -279,7 +278,7 @@ let downloadItemsAsync = async ({
             }),
           }),
           outputPath: outputEpisodeMetaPath,
-          extraFields: includeEpisodeMetaFields,
+          fields,
         });
       } catch (error) {
         hasErrors = true;

--- a/bin/async.js
+++ b/bin/async.js
@@ -159,6 +159,7 @@ let downloadItemsAsync = async ({
   feed,
   filterUrlTracking,
   fields,
+  metadataFormat,
   mono,
   override,
   targetItems,
@@ -252,7 +253,7 @@ let downloadItemsAsync = async ({
     }
 
     if (fields && fields.length) {
-      const episodeMetaExt = ".meta.json";
+      const episodeMetaExt = `.meta.${metadataFormat}`;
       const episodeMetaName = getFilename({
         item,
         feed,

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -163,15 +163,15 @@ const {
 let { archive } = commander;
 
 const getFieldOptionValue = (value, defaultValue) => {
-  // If the option hasn't be used the value is falsy (undefined).
+  // If the option hasn't been provided the value is falsy (undefined).
   if (!value) {
     return value;
   }
-  // If the option has been used with an argument the value is an array.
+  // If the option has been provided with an argument the value is an array.
   if (Array.isArray(value)) {
     return value;
   }
-  // If the option has been used without an argument the value is truthy (true).
+  // If the option has been provided without an argument the value is truthy (true).
   return defaultValue;
 };
 

--- a/bin/bin.js
+++ b/bin/bin.js
@@ -17,6 +17,7 @@ import {
   logItemsList,
   writeFeedMeta,
   ITEM_LIST_FORMATS,
+  METADATA_FORMATS,
 } from "./util.js";
 import { createParseNumber, hasFfmpeg } from "./validate.js";
 import {
@@ -52,15 +53,25 @@ commander
     "template for generating episode related filenames",
     "{{release_date}}-{{title}}"
   )
+  .option("--include-meta [rule]", "write out podcast metadata", collect)
   .option(
-    "--include-meta [rule]",
-    "write out podcast metadata to json",
+    "--include-episode-meta [rule]",
+    "write out individual episode metadata",
     collect
   )
   .option(
-    "--include-episode-meta [rule]",
-    "write out individual episode metadata to json",
-    collect
+    "--metadata-format [json|xml]",
+    "the format to use for the podcast/episode metadata",
+    (value) => {
+      if (value !== METADATA_FORMATS.json && value !== METADATA_FORMATS.xml) {
+        logErrorAndExit(
+          `${value} is an invalid format for --metadata-format\nUse "json" or "xml"`
+        );
+      }
+
+      return value;
+    },
+    METADATA_FORMATS.json
   )
   .option("--include-episode-images", "download found episode images")
   .option(
@@ -143,6 +154,7 @@ const {
   includeMeta,
   includeEpisodeMeta,
   includeEpisodeImages,
+  metadataFormat,
   offset,
   limit,
   episodeRegex,
@@ -253,7 +265,9 @@ const main = async () => {
       }
     }
 
-    const outputMetaName = `${feed.title ? `${feed.title}.meta` : "meta"}.json`;
+    const outputMetaName = `${
+      feed.title ? `${feed.title}.meta` : "meta"
+    }.${metadataFormat}`;
     const outputMetaPath = _path.resolve(basePath, getSafeName(outputMetaName));
 
     try {
@@ -323,6 +337,7 @@ const main = async () => {
       "pubDate",
       "creator",
     ]),
+    metadataFormat,
     mono,
     override,
     targetItems,

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -41,3 +41,33 @@ npx podcast-dl --after "01/01/2021" --before "12/31/2021" --url "http://eightfou
 ```bash
 npx podcast-dl --episode-regex "Zelda" --url "http://eightfour.libsyn.com/rss"
 ```
+
+### Download all episodes + standard set of metadata for the podcast
+
+```bash
+npx podcast-dl --include-meta  --url "http://eightfour.libsyn.com/rss"
+```
+
+### Download all episodes + standard set of metadata for the episodes
+
+```bash
+npx podcast-dl --include-episode-meta  --url "http://eightfour.libsyn.com/rss"
+```
+
+### Download all episodes + all top-level metadata for the episodes (excluding nested fields like `itunes:subtitle`)
+
+```bash
+npx podcast-dl --include-episode-meta '*' --url "http://eightfour.libsyn.com/rss"
+```
+
+### Download all episodes + all metadata for the episodes (including nested fields like `itunes:subtitle`)
+
+```bash
+npx podcast-dl --include-episode-meta '**' --url "http://eightfour.libsyn.com/rss"
+```
+
+### Download all episodes + all metadata for the episodes, except for itunes metadata
+
+```bash
+npx podcast-dl --include-episode-meta '**' --include-episode-meta '!itunes.**' --url "http://eightfour.libsyn.com/rss"
+```

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "p-limit": "^4.0.0",
     "pluralize": "^8.0.0",
     "rss-parser": "^3.7.6",
-    "throttle-debounce": "^3.0.1"
+    "throttle-debounce": "^3.0.1",
+    "xml2js": "^0.4.23"
   }
 }


### PR DESCRIPTION
When archiving with `--include-meta` and `--include-episode-meta` some of the metadata of the podcast and its episodes are saved. The set that is currently saved is only a subset of all the available metadata though, and I'd like to increase this.

It would be trivial to just include all metadata (probably excluding the items listing for the podcast metadata), and I'd totally be happy with that as a solution, but I wanted to try and make it a bit more flexible.

This draft adds two new flags, `--include-meta-fields` and `--include-episode-meta-fields`. As their names suggest these can be used to indicate which extra fields should be included. They can be used multiple times, have simple globbing support (`foo*`), and support negation (`!foobar`).

This does not handle filtering on nested keys yet. I didn't realize that properties like `itunes:subtitle` resulted in a nested structure when making my original design. I can fix this, but I wanted to get some feedback on this before investing more time into it.

A few questions from my side:

0. Would you be interested in functionality to include more metadata?
0. If so, are you interested in the approach I have chosen (flags to specify what to include), or would you want to go for a simpler include-all, or something else entirely?
0. If so, do you have any feelings regarding how to handle nested keys? I'm leaning towards the following:

  - When encountering an object, don't apply the filter to the object itself but instead process it's contents. If any of its contents are to be included the (subset) of the object will be included, and otherwise it will be left out entirely.
  - When checking the filter for nested keys combine the keys with those of their parent(s). For example, `itunes: { subtitle: "foo" }` would result in a key of `itunes.subtitle` which would then be checked against the filter.
  - Change `*` to match anything but `.`.
  - Add `**` that doest match anything, including `.`.

  This way one could easily include everything by passing `**`, or only non-object properties by passing `*`, or perhaps all itunes properties by passing `itunes.**`, etc.

