### PR TITLE
Return false for invalid URLs in getIsAudioUrl()

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -355,7 +355,13 @@ const AUDIO_TYPES_TO_EXTS = {
 const VALID_AUDIO_EXTS = [...new Set(Object.values(AUDIO_TYPES_TO_EXTS))];
 
 const getIsAudioUrl = (url) => {
-  const ext = getUrlExt(url);
+  let ext;
+  try {
+    ext = getUrlExt(url);
+  } catch (err) {
+    // could log a warning here?
+    return false;
+  }
 
   if (!ext) {
     return false;


### PR DESCRIPTION
As mentioned in issue #53, this is to reject malformed URLs when scanning for audio URLs.

I've tested this patch and it resolves the issue with the feed in question.