### PR TITLE
feat(add-mp3-metadata): fix and enhance the --add-mp3-metadata flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Options that support templates allow users to specify a template for the generat
 - `duration`: Provided `mm:ss` duration (if found).
 - `podcast_title`: Title of the podcast feed.
 - `podcast_link`: `link` value provided for the podcast feed. Typically the homepage URL.
+- `guid`: The GUID of the episode.
 
 ### `--exec`
 

--- a/bin/async.js
+++ b/bin/async.js
@@ -215,6 +215,7 @@ let downloadItemsAsync = async ({
               mono,
               itemIndex: item._originalIndex,
               outputPath: outputPodcastPath,
+              addMp3Metadata: addMp3MetadataFlag,
             });
           }
 

--- a/bin/naming.js
+++ b/bin/naming.js
@@ -31,6 +31,7 @@ const getItemFilename = ({ item, ext, url, feed, template, width }) => {
     ["podcast_title", feed.title || ""],
     ["podcast_link", feed.link || ""],
     ["duration", item.itunes?.duration || ""],
+    ["guid", item.guid],
   ];
 
   let name = template;


### PR DESCRIPTION
Fix a bug preventing metadata from being written to audio files. The `--add-mp3-metadata` flag appears to have no effect since [this refactor](https://github.com/lightpohl/podcast-dl/commit/ade68aa6e7612a21e1354143b4d6bf673b20aad4).

[Audiobookshelf](https://www.audiobookshelf.org/) can serve audio files from a directory as a podcast. It supports matching episodes with existing podcasts, but when this is not possible (for example, when old episodes are removed from an rss feed), it also supports importing data from file metadata. The list of supported fields are [here](https://github.com/advplyr/audiobookshelf/blob/v2.4.4/server/objects/entities/PodcastEpisode.js#L198), and the mapping of those fields to tags is [here](https://github.com/advplyr/audiobookshelf/blob/v2.4.4/server/utils/ffmpegHelpers.js#L114). I added the ability to export all tags that audiobookshelf can use.