### PR TITLE
fix: avoid re-encoding cover images when possible

### DIFF
--- a/bin/ffmpeg.js
+++ b/bin/ffmpeg.js
@@ -23,6 +23,7 @@ export const runFfmpeg = async ({
   const shouldEmbedImage = embedMetadata && episodeImageOutputPath;
   const targetFormat = audioFormat ? AUDIO_FORMATS[audioFormat] : null;
   const outputExt = targetFormat ? targetFormat.ext : ext;
+  const usedFullStreamCopy = embedMetadata && !bitrate && !mono && !targetFormat;
 
   let command = `ffmpeg -loglevel quiet -i ${escapeArgForShell(outputPath)}`;
 
@@ -40,15 +41,23 @@ export const runFfmpeg = async ({
 
   if (targetFormat) {
     command += ` -c:a ${targetFormat.codec}`;
-  } else if (embedMetadata && !bitrate && !mono) {
-    command += ` -c:a copy`;
+  } else if (usedFullStreamCopy) {
+    command += ` -c copy`;
   }
 
   if (shouldEmbedImage) {
     const supportsAttachedPic = targetFormat
       ? targetFormat.attachedPic
       : Object.values(AUDIO_FORMATS).find((f) => f.ext === ext)?.attachedPic;
-    command += supportsAttachedPic ? ` -c:v copy -disposition:v:0 attached_pic` : ` -c:v copy`;
+    if (usedFullStreamCopy) {
+      if (supportsAttachedPic) {
+        command += ` -disposition:v:0 attached_pic`;
+      }
+    } else {
+      command += supportsAttachedPic ? ` -c:v copy -disposition:v:0 attached_pic` : ` -c:v copy`;
+    }
+  } else if (embedMetadata && (bitrate || mono) && !targetFormat) {
+    command += ` -c:v copy`;
   }
 
   if (embedMetadata) {

--- a/bin/ffmpeg.js
+++ b/bin/ffmpeg.js
@@ -22,8 +22,12 @@ export const runFfmpeg = async ({
 
   const shouldEmbedImage = embedMetadata && episodeImageOutputPath;
   const targetFormat = audioFormat ? AUDIO_FORMATS[audioFormat] : null;
+  const sourceFormat = Object.values(AUDIO_FORMATS).find((format) => format.ext === ext);
   const outputExt = targetFormat ? targetFormat.ext : ext;
   const usedFullStreamCopy = embedMetadata && !bitrate && !mono && !targetFormat;
+  const supportsAttachedPic = (targetFormat || sourceFormat)?.attachedPic;
+  const shouldCopyVideo = shouldEmbedImage || (embedMetadata && (bitrate || mono) && !targetFormat);
+  const shouldMarkAttachedPic = shouldEmbedImage && supportsAttachedPic;
 
   let command = `ffmpeg -loglevel quiet -i ${escapeArgForShell(outputPath)}`;
 
@@ -45,19 +49,12 @@ export const runFfmpeg = async ({
     command += ` -c copy`;
   }
 
-  if (shouldEmbedImage) {
-    const supportsAttachedPic = targetFormat
-      ? targetFormat.attachedPic
-      : Object.values(AUDIO_FORMATS).find((f) => f.ext === ext)?.attachedPic;
-    if (usedFullStreamCopy) {
-      if (supportsAttachedPic) {
-        command += ` -disposition:v:0 attached_pic`;
-      }
-    } else {
-      command += supportsAttachedPic ? ` -c:v copy -disposition:v:0 attached_pic` : ` -c:v copy`;
-    }
-  } else if (embedMetadata && (bitrate || mono) && !targetFormat) {
+  if (shouldCopyVideo && !usedFullStreamCopy) {
     command += ` -c:v copy`;
+  }
+
+  if (shouldMarkAttachedPic) {
+    command += ` -disposition:v:0 attached_pic`;
   }
 
   if (embedMetadata) {


### PR DESCRIPTION
- Avoid re-encoding cover images when possible
- The main problematic path was when using `--embed-metadata` with no other `ffmpeg` related flags

Fixes #151 