### PR TITLE
feat: add release_{time,hour,minute,second} template variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Options that support templates allow users to specify a template for the generat
 - `release_year`: The release year (`YYYY`) of the episode.
 - `release_month`: The release month (`MM`) of the episode.
 - `release_day`: The release day (`DD`) of the episode.
+- `release_time`: The release time of the episode in `HHmmss` format.
+- `release_hour`: The release hour (`HH`) of the episode.
+- `release_minute`: The release minute (`mm`) of the episode.
+- `release_second`: The release second (`ss`) of the episode.
 - `episode_num`: The position number of where the episode appears in the feed.
 - `url`: URL of episode audio file.
 - `duration`: Provided `mm:ss` duration (if found).

--- a/bin/naming.js
+++ b/bin/naming.js
@@ -74,6 +74,10 @@ export const getItemFilename = ({
   const releaseMonth = pubDateParsed?.format("MM") ?? null;
   const releaseDay = pubDateParsed?.format("DD") ?? null;
   const releaseDate = pubDateParsed?.format("YYYYMMDD") ?? null;
+  const releaseTime = pubDateParsed?.format("HHmmss") ?? null;
+  const releaseHour = pubDateParsed?.format("HH") ?? null;
+  const releaseMinute = pubDateParsed?.format("mm") ?? null;
+  const releaseSecond = pubDateParsed?.format("ss") ?? null;
 
   const customReplacementTuples = customTemplateOptions.map((option, i) => {
     if (!customRegexCache.has(option)) {
@@ -90,6 +94,10 @@ export const getItemFilename = ({
     ["release_year", releaseYear || ""],
     ["release_month", releaseMonth || ""],
     ["release_day", releaseDay || ""],
+    ["release_time", releaseTime || ""],
+    ["release_hour", releaseHour || ""],
+    ["release_minute", releaseMinute || ""],
+    ["release_second", releaseSecond || ""],
     ["episode_num", `${episodeNum}`.padStart(width, "0")],
     ["url", url],
     ["podcast_title", feed.title || ""],

--- a/bin/naming.test.js
+++ b/bin/naming.test.js
@@ -68,12 +68,12 @@ describe("getItemFilename", () => {
         items: new Array(15).fill(null),
       },
       template:
-        "{{podcast_title|trim|dash}}/{{release_date}}-{{episode_num}}-{{title|trim|strip_special|underscore}}-{{custom_0|uppercase}}",
+        "{{podcast_title|trim|dash}}/{{release_date}}-{{release_time}}-{{episode_num}}-{{title|trim|strip_special|underscore}}-{{custom_0|uppercase}}",
       width: 3,
       customTemplateOptions: ["S\\d+E\\d+"],
     });
 
-    expect(result).toBe(path.join("My-Podcast", "20240102-013-Great_Episode_S01E02-S01E02.mp3"));
+    expect(result).toBe(path.join("My-Podcast", "20240102-120000-013-Great_Episode_S01E02-S01E02.mp3"));
   });
 
   it("truncates directory and file segments independently", async () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,1 +1,1 @@
-export default { test: { environment: "node" } };
+export default { test: { environment: "node", env: { TZ: "UTC" } } };


### PR DESCRIPTION
I have a podcast that has multiple episodes released on the same day. To make sure my episodes are correctly ordered, I need the time to appear in the filename.