### PR TITLE
fix: resolve video enclosure URLs after MIME map refactor

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -199,9 +199,13 @@ export const TRANSCRIPT_TYPES_TO_EXTS = {
   "text/vtt": ".vtt",
 };
 
-export const MIME_TO_EXT = {
+export const MEDIA_TYPES_TO_EXTS = {
   ...AUDIO_TYPES_TO_EXTS,
   ...VIDEO_TYPES_TO_EXTS,
+};
+
+export const MIME_TO_EXT = {
+  ...MEDIA_TYPES_TO_EXTS,
   ...IMAGE_TYPES_TO_EXTS,
   ...TRANSCRIPT_TYPES_TO_EXTS,
 };
@@ -288,7 +292,7 @@ export const getIsAudioUrl = (url) => {
     return false;
   }
 
-  return VALID_AUDIO_EXTS_SET.has(ext);
+  return VALID_AUDIO_EXTS_SET.has(ext) || VIDEO_EXTS.has(ext);
 };
 
 export const AUDIO_ORDER_TYPES = {
@@ -313,10 +317,10 @@ export const getEpisodeAudioUrlAndExt = (
         };
       }
 
-      if (enclosure.url && AUDIO_TYPES_TO_EXTS[enclosure.type]) {
+      if (enclosure.url && MEDIA_TYPES_TO_EXTS[enclosure.type]) {
         return {
           url: normalizeUrl(enclosure.url),
-          ext: AUDIO_TYPES_TO_EXTS[enclosure.type],
+          ext: MEDIA_TYPES_TO_EXTS[enclosure.type],
         };
       }
     }

--- a/bin/util.test.js
+++ b/bin/util.test.js
@@ -173,6 +173,12 @@ describe("getIsAudioUrl", () => {
     expect(getIsAudioUrl("https://example.com/ep.m4a")).toBe(true);
   });
 
+  it("returns true for URL with video extension", () => {
+    expect(getIsAudioUrl("https://example.com/ep.mp4")).toBe(true);
+    expect(getIsAudioUrl("https://example.com/ep.mov")).toBe(true);
+    expect(getIsAudioUrl("https://example.com/ep.m4v")).toBe(true);
+  });
+
   it("returns false for URL without audio extension", () => {
     expect(getIsAudioUrl("https://example.com/page.html")).toBe(false);
     expect(getIsAudioUrl("https://example.com/")).toBe(false);
@@ -240,6 +246,27 @@ describe("getEpisodeAudioUrlAndExt", () => {
       enclosure: { url: "https://example.com/ep", type: "audio/mpeg" },
     });
     expect(result).toEqual({ url: "https://example.com/ep", ext: ".mp3" });
+  });
+
+  it("resolves a video enclosure URL (mp4)", () => {
+    const result = getEpisodeAudioUrlAndExt({
+      enclosure: { url: "https://example.com/ep.mp4", type: "video/mp4" },
+    });
+    expect(result).toEqual({ url: "https://example.com/ep.mp4", ext: ".mp4" });
+  });
+
+  it("resolves a video enclosure URL (mov)", () => {
+    const result = getEpisodeAudioUrlAndExt({
+      enclosure: { url: "https://example.com/ep.mov", type: "video/quicktime" },
+    });
+    expect(result).toEqual({ url: "https://example.com/ep.mov", ext: ".mov" });
+  });
+
+  it("uses enclosure type when URL has no video ext", () => {
+    const result = getEpisodeAudioUrlAndExt({
+      enclosure: { url: "https://example.com/ep", type: "video/mp4" },
+    });
+    expect(result).toEqual({ url: "https://example.com/ep", ext: ".mp4" });
   });
 
   it("falls back to link when enclosure not audio", () => {


### PR DESCRIPTION
Hey, it seems the last refactor inadvertently stopped video downloads.

I was getting errors like these:
```
podcast-dl  | 2026-08-15T07:15:15.136569462Z Starting download of 5 episodes
podcast-dl  | 2026-08-15T07:15:15.136572844Z 
podcast-dl  | 2026-08-15T07:15:15.137099430Z Episode_Name | Unable to find episode download URL
```

Took a look and it seems that moving the video/* MIME types out of `AUDIO_TYPES_TO_EXTS` was the culprit, since `getIsAudioUrl`/`getEpisodeAudioUrlAndExt` validated against them, resulting in video enclosures now resolving to `{ url: null }`

To fix this I changed `getIsAudioUrl` to also accept `VIDEO_EXTS` and added a new `MEDIA_TYPES_TO_EXTS` for the enclosure-type fallback.

**Note:** 
not sure if `getIsAudioUrl` should be renamed (maybe `getIsMediaUrl`?), left it as is for now, since I didn't want to broadly change the name here, since there are more things that are named something with audio, but are technically already functioning for video as well.

**Related:**
I also noticed that the refactor left `getExtCategory`/`getMimeCategory` without a video category, which causes `correctExtensionFromMime`'s cross-category guard to no longer protect video files (e.g. a server misreporting `Content-Type: audio/mpeg` for an .mp4 download would rename it to .mp3

If you want I can add another commit for that as well in this PR